### PR TITLE
Fix Folder Whitelist not working when full paths are disabled

### DIFF
--- a/DynamicBridge/Gui/GuiPresets.cs
+++ b/DynamicBridge/Gui/GuiPresets.cs
@@ -390,8 +390,9 @@ namespace DynamicBridge.Gui
                                     {
                                         var name = x.Name;
                                         var id = x.Identifier.ToString();
-                                        var transformedName = P.GlamourerManager.TransformName(x.Identifier.ToString());
-                                        if(C.GlamourerFullPath && currentProfile.Pathes.Count > 0 && !transformedName.StartsWithAny(currentProfile.Pathes)) continue;
+                                        var fullPath = P.GlamourerManager.GetFullPath(id);
+                                        var transformedName = P.GlamourerManager.TransformName(id);
+                                        if(currentProfile.Pathes.Count > 0 && !fullPath.StartsWithAny(currentProfile.Pathes)) continue;
                                         if(Filters[filterCnt].Length > 0 && !transformedName.Contains(Filters[filterCnt], StringComparison.OrdinalIgnoreCase)) continue;
                                         var contains = preset.Glamourer.Contains(id);
                                         if(OnlySelected[filterCnt] && !contains) continue;
@@ -489,7 +490,8 @@ namespace DynamicBridge.Gui
                                     index++;
                                     ImGui.PushID(index);
                                     var name = P.CustomizePlusManager.TransformName($"{x.UniqueId}");
-                                    if(C.GlamourerFullPath && currentProfile.CustomizePathes.Count > 0 && !name.StartsWithAny(currentProfile.CustomizePathes)) continue;
+                                    var fullPath = P.CustomizePlusManager.GetFullPath($"{x.UniqueId}");
+                                    if(currentProfile.CustomizePathes.Count > 0 && !fullPath.StartsWithAny(currentProfile.CustomizePathes)) continue;
                                     if(Filters[filterCnt].Length > 0 && !name.Contains(Filters[filterCnt], StringComparison.OrdinalIgnoreCase)) continue;
                                     if(OnlySelected[filterCnt] && !preset.Customize.Contains($"{x.UniqueId}")) continue;
                                     var contains = preset.Customize.Contains($"{x.UniqueId}");

--- a/DynamicBridge/IPC/Customize/CustomizePlusManager.cs
+++ b/DynamicBridge/IPC/Customize/CustomizePlusManager.cs
@@ -152,4 +152,16 @@ public class CustomizePlusManager
         }
         return originalName;
     }
+
+    public string GetFullPath(string originalName)
+    {
+        if (Guid.TryParse(originalName, out var guid))
+        {
+            if (GetProfiles().TryGetFirst(x => x.UniqueId == guid, out var entry))
+            {
+                return entry.VirtualPath;
+            }
+        }
+        return originalName;
+    }
 }

--- a/DynamicBridge/IPC/Customize/CustomizePlusManager.cs
+++ b/DynamicBridge/IPC/Customize/CustomizePlusManager.cs
@@ -136,32 +136,53 @@ public class CustomizePlusManager
     }
 
 
-
+    private Dictionary<string, string> TransformNameCache = [];
     public string TransformName(string originalName)
     {
-        if(Guid.TryParse(originalName, out var guid))
+        if (TransformNameCache.TryGetValue(originalName, out var ret))
+        {
+            return ret;
+        }
+        if (Guid.TryParse(originalName, out var guid))
         {
             if(GetProfiles().TryGetFirst(x => x.UniqueId == guid, out var entry))
             {
                 if(C.GlamourerFullPath)
                 {
-                    return entry.VirtualPath;
+                    return CacheAndReturn(entry.VirtualPath);
                 }
-                return entry.Name;
+                return CacheAndReturn(entry.Name);
             }
         }
-        return originalName;
+        return CacheAndReturn(originalName);
+
+        string CacheAndReturn(string name)
+        {
+            TransformNameCache[originalName] = name;
+            return TransformNameCache[originalName];
+        }
     }
 
+    private Dictionary<string, string> FullPathCache = [];
     public string GetFullPath(string originalName)
     {
+        if (FullPathCache.TryGetValue(originalName, out var ret))
+        {
+            return ret;
+        }
         if (Guid.TryParse(originalName, out var guid))
         {
             if (GetProfiles().TryGetFirst(x => x.UniqueId == guid, out var entry))
             {
-                return entry.VirtualPath;
+                return CacheAndReturn(entry.VirtualPath);
             }
         }
-        return originalName;
+        return CacheAndReturn(originalName);
+
+        string CacheAndReturn(string name)
+        {
+            FullPathCache[originalName] = name;
+            return FullPathCache[originalName];
+        }
     }
 }

--- a/DynamicBridge/IPC/Glamourer/GlamourerManager.cs
+++ b/DynamicBridge/IPC/Glamourer/GlamourerManager.cs
@@ -154,6 +154,29 @@ public unsafe class GlamourerManager
         }
     }
 
+    private Dictionary<string, string> FullPathCache = [];
+    public string GetFullPath(string originalName)
+    {
+        if(FullPathCache.TryGetValue(originalName, out var ret))
+        {
+            return ret; 
+        }
+        if (Guid.TryParse(originalName, out var guid))
+        {
+            if (GetDesigns().TryGetFirst(x => x.Identifier == guid, out var entry))
+            {
+                return CacheAndReturn(Reflector.GetPathForDesignByGuid(guid) ?? entry.Name);
+            }
+        }
+        return CacheAndReturn(originalName);
+
+        string CacheAndReturn(string name)
+        {
+            FullPathCache[originalName] = name;
+            return FullPathCache[originalName];
+        }
+    }
+
     public List<string> GetRawPathes()
     {
         var ret = new List<string>();


### PR DESCRIPTION
This should get Folder Whitelist working even if user has Full Paths disabled. At the moment if user disables full paths in settings the dropdowns will ignore the whitelist and display all possible entries. 

This removes the full paths option check allowing the whitelist to be applied regardless of the setting, with this option disabled transformName doesn't contain full paths so I implemented additional methods to allow for fetching full paths regardless of the setting.

Additionally I added caching to C+ manager to put it in line with Glamourer manager