### PR TITLE
Add a toggle to reapply rules and presets on glamourer change

### DIFF
--- a/DynamicBridge/Configuration/Config.cs
+++ b/DynamicBridge/Configuration/Config.cs
@@ -29,6 +29,7 @@ namespace DynamicBridge.Configuration
         public bool ManageGlamourerAutomation = false;
         public bool AllowNegativeConditions = false;
         public bool GlamourerFullPath = false;
+        public bool AutoApplyOnChange = false;
         public string LastVersion = "0";
         public ImGuiComboFlags ComboSize = ImGuiComboFlags.HeightLarge;
         public bool UpdateJobGSChange = true;

--- a/DynamicBridge/Gui/GuiPresets.cs
+++ b/DynamicBridge/Gui/GuiPresets.cs
@@ -396,13 +396,16 @@ namespace DynamicBridge.Gui
                                         if(Filters[filterCnt].Length > 0 && !transformedName.Contains(Filters[filterCnt], StringComparison.OrdinalIgnoreCase)) continue;
                                         var contains = preset.Glamourer.Contains(id);
                                         if(OnlySelected[filterCnt] && !contains) continue;
-
                                         items.Add((transformedName.SplitDirectories()[0..^1], () =>
                                         {
                                             if(Utils.CollectionSelectable(contains ? Colors.TabGreen : null, $"{name}  ##{x.Identifier}", id, preset.Glamourer))
                                             {
                                                 if(C.AutofillFromGlam && preset.Name == "" && preset.Glamourer.Contains(id)) preset.Name = name;
-                                            }
+                                                if(C.AutoApplyOnChange)
+                                                {
+                                                    P.ForceUpdate = true;
+                                                }
+                                            }                                           
                                         }
 
                                         ));
@@ -431,6 +434,10 @@ namespace DynamicBridge.Gui
                                             if(Utils.CollectionSelectable(contains ? Colors.TabYellow : null, $"{name}##{x.GUID}", name, preset.ComplexGlamourer))
                                             {
                                                 if(C.AutofillFromGlam && preset.Name == "" && preset.ComplexGlamourer.Contains(name)) preset.Name = name;
+                                                if(C.AutoApplyOnChange)
+                                                {
+                                                    P.ForceUpdate = true;
+                                                }
                                             }
                                         }
                                         ));

--- a/DynamicBridge/Gui/GuiSettings.cs
+++ b/DynamicBridge/Gui/GuiSettings.cs
@@ -36,6 +36,7 @@ public static class GuiSettings
             ImGuiEx.HelpMarker("If you will enable this option, you will be able to mark any condition with cross marker. If any condition marked with cross within the rule is matching, that entire rule is ignored.");
             ImGui.Checkbox("Display full path in profile editor, where available", ref C.GlamourerFullPath);
             ImGuiEx.SetNextItemWidthScaled(150f);
+            ImGui.Checkbox("Reapply rules and presets on change in Glamourer dropdowns", ref C.AutoApplyOnChange);
             ImGuiEx.EnumCombo("Dropdown menu size", ref C.ComboSize, ComboFlagNames.ContainsKey, ComboFlagNames);
             if(ImGui.Checkbox($"Force update appearance on job and gearset changes", ref C.UpdateJobGSChange))
             {

--- a/DynamicBridge/Gui/UI.cs
+++ b/DynamicBridge/Gui/UI.cs
@@ -177,6 +177,6 @@ public static unsafe class UI
         {
             P.ForceUpdate = true;
         }
-        ImGuiEx.Tooltip("Force update your character, reapplying all rules and resets");
+        ImGuiEx.Tooltip("Force update your character, reapplying all rules and presets");
     }
 }


### PR DESCRIPTION
Adds a toggle in settings that force updates whenever a glamourer design is enabled/disabled in glamourer dropdown in Presets tab

Also fixes a typo? It looks like it's a typo.

