### PR TITLE
Fix swapping between 2 profiles when both have static preset

### DIFF
--- a/DynamicBridge/Gui/GuiCharacters.cs
+++ b/DynamicBridge/Gui/GuiCharacters.cs
@@ -49,6 +49,9 @@ public static class GuiCharacters
                         if(currentProfile == profile && ImGui.IsWindowAppearing()) ImGui.SetScrollHereY();
                         if(ImGui.Selectable($"{profile.CensoredName}##{profile.GUID}", currentProfile == profile))
                         {
+                            if(currentProfile.IsStaticExists() && profile.IsStaticExists()){
+                                P.ForceUpdate = true;
+                            }
                             profile.SetCharacter(x.Key);
                         }
                     }


### PR DESCRIPTION
As in title, In scenario when user swaps between 2 profiles and both have static presets update wouldn't get triggered, most likely because there is no rule to be applied so automation is disabled