### PR TITLE
Further fixes to swapping profiles with static presets

### DIFF
--- a/DynamicBridge/DynamicBridge.cs
+++ b/DynamicBridge/DynamicBridge.cs
@@ -183,11 +183,16 @@ public unsafe class DynamicBridge : IDalamudPlugin
             {
                 var name = arguments[(arguments.IndexOf(" ") + 1)..];
                 var profile = C.ProfilesL.FirstOrDefault(p => p.Name == name);
+                var currentProfile = C.ProfilesL.FirstOrDefault(z => z.Characters.Contains(Player.CID));
 
                 if(profile != null)
                 {
                     if(C.SeenCharacters.ContainsKey(Player.CID) && !C.Blacklist.Contains(Player.CID))
                     {
+                        if (profile.IsStaticExists() && (currentProfile == null || currentProfile.IsStaticExists()))
+                        {
+                            P.ForceUpdate = true;
+                        }
                         profile.SetCharacter(Player.CID);
 
                     }

--- a/DynamicBridge/Gui/GuiCharacters.cs
+++ b/DynamicBridge/Gui/GuiCharacters.cs
@@ -49,7 +49,7 @@ public static class GuiCharacters
                         if(currentProfile == profile && ImGui.IsWindowAppearing()) ImGui.SetScrollHereY();
                         if(ImGui.Selectable($"{profile.CensoredName}##{profile.GUID}", currentProfile == profile))
                         {
-                            if(currentProfile.IsStaticExists() && profile.IsStaticExists()){
+                            if(profile.IsStaticExists() && (currentProfile == null || currentProfile.IsStaticExists())){
                                 P.ForceUpdate = true;
                             }
                             profile.SetCharacter(x.Key);


### PR DESCRIPTION
Sorry for not catching this in my initial PR.

1. Added check to the command as well since it had the same issue
2. refined logic - IsStaticExists throws exception if user comes from "No Profile" setting due to currentProfile being null. Updated logic shouldn't throw anything and also allow for force update if user comes from "No Profile" setting as this was being affected as well.