### PR TITLE
Sticky things.

### DIFF
--- a/DynamicBridge/Configuration/ApplyRule.cs
+++ b/DynamicBridge/Configuration/ApplyRule.cs
@@ -12,6 +12,7 @@ namespace DynamicBridge.Configuration
     public class ApplyRule
     {
         [NonSerialized] internal string GUID = Guid.NewGuid().ToString();
+        public int StickyRandom = 0;
         public bool Enabled = true;
 
         public List<CharacterState> States = [];

--- a/DynamicBridge/Configuration/Config.cs
+++ b/DynamicBridge/Configuration/Config.cs
@@ -1,4 +1,4 @@
-﻿using ECommons.Configuration;
+using ECommons.Configuration;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -42,6 +42,7 @@ namespace DynamicBridge.Configuration
         public bool StickyPenumbra = false;
         public RandomTypes RandomChoosenType = RandomTypes.OnLogin;
         public double UserInputRandomizerTime = 5;
+        public bool ForceUpdateOnRandomize = false;
         public bool UpdateGearChange = false;
         public Dictionary<ulong, string> SeenCharacters = [];
 

--- a/DynamicBridge/Configuration/Config.cs
+++ b/DynamicBridge/Configuration/Config.cs
@@ -33,6 +33,13 @@ namespace DynamicBridge.Configuration
         public string LastVersion = "0";
         public ImGuiComboFlags ComboSize = ImGuiComboFlags.HeightLarge;
         public bool UpdateJobGSChange = true;
+        public bool DontChangeOnTerritoryChange = false;
+        public bool Sticky = false;
+        public bool StickyPresets = false;
+        public bool StickyGlamourer = false;
+        public bool StickyCustomize = false;
+        public bool StickyHonorific = false;
+        public bool StickyPenumbra = false;
         public bool UpdateGearChange = false;
         public Dictionary<ulong, string> SeenCharacters = [];
 

--- a/DynamicBridge/Configuration/Config.cs
+++ b/DynamicBridge/Configuration/Config.cs
@@ -33,7 +33,6 @@ namespace DynamicBridge.Configuration
         public string LastVersion = "0";
         public ImGuiComboFlags ComboSize = ImGuiComboFlags.HeightLarge;
         public bool UpdateJobGSChange = true;
-        public bool DontChangeOnTerritoryChange = false;
         public bool Sticky = false;
         public bool StickyPresets = false;
         public bool StickyGlamourer = false;

--- a/DynamicBridge/Configuration/Config.cs
+++ b/DynamicBridge/Configuration/Config.cs
@@ -40,6 +40,8 @@ namespace DynamicBridge.Configuration
         public bool StickyCustomize = false;
         public bool StickyHonorific = false;
         public bool StickyPenumbra = false;
+        public RandomTypes RandomChoosenType = RandomTypes.OnLogin;
+        public double UserInputRandomizerTime = 5;
         public bool UpdateGearChange = false;
         public Dictionary<ulong, string> SeenCharacters = [];
 
@@ -71,5 +73,11 @@ namespace DynamicBridge.Configuration
         RevertToNormal,
         RevertToAutomation,
         StoreRestore
+    }
+    public enum RandomTypes
+    {
+        OnLogin,
+        Never,
+        Timer
     }
 }

--- a/DynamicBridge/Configuration/Preset.cs
+++ b/DynamicBridge/Configuration/Preset.cs
@@ -20,5 +20,9 @@ namespace DynamicBridge.Configuration
         public List<MoodleInfo> Moodles = [];
         public SpecialPenumbraAssignment PenumbraType = SpecialPenumbraAssignment.Use_Named_Collection;
         public bool IsStatic = false;
+        public int StickyRandomG = 0;
+        public int StickyRandomH = 0;
+        public int StickyRandomC = 0;
+        public int StickyRandomP = 0;
     }
 }

--- a/DynamicBridge/DynamicBridge.cs
+++ b/DynamicBridge/DynamicBridge.cs
@@ -167,7 +167,7 @@ public unsafe class DynamicBridge : IDalamudPlugin
             }
         }
         }
-        ForceUpdate = C.ForceUpdateOnRandomize && C.Sticky && (C.StickyPresets||C.StickyCustomize||C.StickyGlamourer||C.StickyHonorific||C.StickyPenumbra);
+        ForceUpdate = C.ForceUpdateOnRandomize && C.Sticky && (C.StickyPresets||C.StickyCustomize||C.StickyGlamourer||C.StickyHonorific||C.StickyPenumbra) && (C.UserInputRandomizerTime >= 0.75);
         RandomizedRecently = false;
     }
 

--- a/DynamicBridge/DynamicBridge.cs
+++ b/DynamicBridge/DynamicBridge.cs
@@ -326,6 +326,7 @@ public unsafe class DynamicBridge : IDalamudPlugin
                         if(rule != null && rule.SelectedPresets.Count > 0)
                         {
                             var index = Random.Next(0, rule.SelectedPresets.Count);
+                            if (C.StickyPresets) {index = rule.StickyRandom;}
                             var preset = profile.GetPresetsUnion().FirstOrDefault(s => s.Name == rule.SelectedPresets[index]);
                             if(preset != null)
                             {
@@ -492,7 +493,9 @@ public unsafe class DynamicBridge : IDalamudPlugin
         }
         else if(preset.Penumbra.Count > 0)
         {
-            var randomAssignment = preset.Penumbra[Random.Next(preset.Penumbra.Count)];
+            int index = Random.Next(preset.Penumbra.Count);
+            if (C.StickyPenumbra) {index = preset.StickyRandomP;}
+            var randomAssignment = preset.Penumbra[index];
             PenumbraManager.SetAssignment(randomAssignment);
             DoNullPenumbra = false;
         }
@@ -503,6 +506,7 @@ public unsafe class DynamicBridge : IDalamudPlugin
         if(preset.Glamourer.Count > 0 || preset.ComplexGlamourer.Count > 0)
         {
             var selectedIndex = Random.Shared.Next(0, preset.Glamourer.Count + preset.ComplexGlamourer.Count);
+            if (C.StickyGlamourer) {selectedIndex = preset.StickyRandomG;}
             var designs = new List<string>();
             if(selectedIndex < preset.Glamourer.Count)
             {
@@ -552,7 +556,9 @@ public unsafe class DynamicBridge : IDalamudPlugin
         if(hfiltered.Length > 0)
         {
             DoNullHonorific = false;
-            var randomTitle = hfiltered[Random.Next(hfiltered.Length)];
+            var index = Random.Next(hfiltered.Length);
+            if (C.StickyHonorific) {index = preset.StickyRandomH;};
+            var randomTitle = hfiltered[index];
             TaskManager.Enqueue(Utils.WaitUntilInteractable);
             TaskManager.Enqueue(() => HonorificManager.SetTitle(randomTitle));
         }
@@ -564,7 +570,9 @@ public unsafe class DynamicBridge : IDalamudPlugin
         if(cfiltered.Length > 0)
         {
             DoNullCustomize = false;
-            var randomCusProfile = cfiltered[Random.Next(cfiltered.Length)];
+            var index = Random.Next(cfiltered.Length);
+            if (C.StickyCustomize) {index = preset.StickyRandomC;};
+            var randomCusProfile = cfiltered[index];
             TaskManager.Enqueue(Utils.WaitUntilInteractable);
             TaskManager.Enqueue(() => CustomizePlusManager.SetProfile(randomCusProfile, Player.NameWithWorld));
         }

--- a/DynamicBridge/DynamicBridge.cs
+++ b/DynamicBridge/DynamicBridge.cs
@@ -142,26 +142,26 @@ public unsafe class DynamicBridge : IDalamudPlugin
     private void Randomizer() {
         var profile = Utils.GetProfileByCID(Player.CID);
         if (profile != null) {
-            if (C.StickyPresets) {
+            if (C.StickyPresets && C.Sticky) {
                 foreach (var rule in profile.Rules) 
                 {
                 rule.StickyRandom = Random.Shared.Next(0, rule.SelectedPresets.Count);
             }
             }
             foreach (var preset in profile.Presets) {
-                if (C.StickyCustomize)
+                if (C.StickyCustomize && C.Sticky)
                 {
                 preset.StickyRandomC = Random.Shared.Next(0, preset.CustomizeFiltered().ToArray().Length);
                 }
-                if (C.StickyGlamourer)
+                if (C.StickyGlamourer && C.Sticky)
                 {
                 preset.StickyRandomG = Random.Shared.Next(0, preset.Glamourer.Count + preset.ComplexGlamourer.Count);
                 }
-                if (C.StickyHonorific)
+                if (C.StickyHonorific && C.Sticky)
                 {
                 preset.StickyRandomH = Random.Shared.Next(0, preset.HonorificFiltered().ToArray().Length);
                 }
-                if (C.StickyPenumbra)
+                if (C.StickyPenumbra && C.Sticky)
                 {
                 preset.StickyRandomP = Random.Shared.Next(0, preset.Penumbra.Count);
             }
@@ -373,7 +373,7 @@ public unsafe class DynamicBridge : IDalamudPlugin
                         if(rule != null && rule.SelectedPresets.Count > 0)
                         {
                             var index = Random.Next(0, rule.SelectedPresets.Count);
-                            if (C.StickyPresets)
+                            if (C.StickyPresets && C.Sticky)
                             {
                                 index = rule.StickyRandom;
                             }
@@ -544,7 +544,7 @@ public unsafe class DynamicBridge : IDalamudPlugin
         else if(preset.Penumbra.Count > 0)
         {
             int index = Random.Next(preset.Penumbra.Count);
-            if (C.StickyPenumbra) {index = preset.StickyRandomP;}
+            if (C.StickyPenumbra && C.Sticky) {index = preset.StickyRandomP;}
             var randomAssignment = preset.Penumbra[index];
             PenumbraManager.SetAssignment(randomAssignment);
             DoNullPenumbra = false;
@@ -556,7 +556,7 @@ public unsafe class DynamicBridge : IDalamudPlugin
         if(preset.Glamourer.Count > 0 || preset.ComplexGlamourer.Count > 0)
         {
             var selectedIndex = Random.Shared.Next(0, preset.Glamourer.Count + preset.ComplexGlamourer.Count);
-            if (C.StickyGlamourer) {selectedIndex = preset.StickyRandomG;}
+            if (C.StickyGlamourer && C.Sticky) {selectedIndex = preset.StickyRandomG;}
             var designs = new List<string>();
             if(selectedIndex < preset.Glamourer.Count)
             {
@@ -607,7 +607,7 @@ public unsafe class DynamicBridge : IDalamudPlugin
         {
             DoNullHonorific = false;
             var index = Random.Next(hfiltered.Length);
-            if (C.StickyHonorific) {index = preset.StickyRandomH;};
+            if (C.StickyHonorific && C.Sticky) {index = preset.StickyRandomH;};
             var randomTitle = hfiltered[index];
             TaskManager.Enqueue(Utils.WaitUntilInteractable);
             TaskManager.Enqueue(() => HonorificManager.SetTitle(randomTitle));
@@ -621,7 +621,7 @@ public unsafe class DynamicBridge : IDalamudPlugin
         {
             DoNullCustomize = false;
             var index = Random.Next(cfiltered.Length);
-            if (C.StickyCustomize) {index = preset.StickyRandomC;};
+            if (C.StickyCustomize && C.Sticky) {index = preset.StickyRandomC;};
             var randomCusProfile = cfiltered[index];
             TaskManager.Enqueue(Utils.WaitUntilInteractable);
             TaskManager.Enqueue(() => CustomizePlusManager.SetProfile(randomCusProfile, Player.NameWithWorld));

--- a/DynamicBridge/DynamicBridge.cs
+++ b/DynamicBridge/DynamicBridge.cs
@@ -1,4 +1,4 @@
-﻿using DynamicBridge.Configuration;
+using DynamicBridge.Configuration;
 using DynamicBridge.Core;
 using DynamicBridge.Gui;
 using DynamicBridge.IPC;
@@ -277,7 +277,7 @@ public unsafe class DynamicBridge : IDalamudPlugin
                 RandomizedRecently = true;
                 RandomizerTimer = DateTime.UtcNow;
                 Randomizer();
-                ForceUpdate = true;
+                ForceUpdate = C.ForceUpdateOnRandomize;
             }
 
             var profile = Utils.GetProfileByCID(Player.CID);

--- a/DynamicBridge/DynamicBridge.cs
+++ b/DynamicBridge/DynamicBridge.cs
@@ -142,16 +142,32 @@ public unsafe class DynamicBridge : IDalamudPlugin
     private void Randomizer() {
         var profile = Utils.GetProfileByCID(Player.CID);
         if (profile != null) {
-            foreach (var rule in profile.Rules) {
+            if (C.StickyPresets) {
+                foreach (var rule in profile.Rules) 
+                {
                 rule.StickyRandom = Random.Shared.Next(0, rule.SelectedPresets.Count);
             }
+            }
             foreach (var preset in profile.Presets) {
+                if (C.StickyCustomize)
+                {
                 preset.StickyRandomC = Random.Shared.Next(0, preset.CustomizeFiltered().ToArray().Length);
+                }
+                if (C.StickyGlamourer)
+                {
                 preset.StickyRandomG = Random.Shared.Next(0, preset.Glamourer.Count + preset.ComplexGlamourer.Count);
+                }
+                if (C.StickyHonorific)
+                {
                 preset.StickyRandomH = Random.Shared.Next(0, preset.HonorificFiltered().ToArray().Length);
+                }
+                if (C.StickyPenumbra)
+                {
                 preset.StickyRandomP = Random.Shared.Next(0, preset.Penumbra.Count);
             }
         }
+        }
+        ForceUpdate = C.ForceUpdateOnRandomize && C.Sticky && (C.StickyPresets||C.StickyCustomize||C.StickyGlamourer||C.StickyHonorific||C.StickyPenumbra);
         RandomizedRecently = false;
     }
 
@@ -277,7 +293,6 @@ public unsafe class DynamicBridge : IDalamudPlugin
                 RandomizedRecently = true;
                 RandomizerTimer = DateTime.UtcNow;
                 Randomizer();
-                ForceUpdate = C.ForceUpdateOnRandomize;
             }
 
             var profile = Utils.GetProfileByCID(Player.CID);
@@ -358,7 +373,10 @@ public unsafe class DynamicBridge : IDalamudPlugin
                         if(rule != null && rule.SelectedPresets.Count > 0)
                         {
                             var index = Random.Next(0, rule.SelectedPresets.Count);
-                            if (C.StickyPresets) {index = rule.StickyRandom;}
+                            if (C.StickyPresets)
+                            {
+                                index = rule.StickyRandom;
+                            }
                             var preset = profile.GetPresetsUnion().FirstOrDefault(s => s.Name == rule.SelectedPresets[index]);
                             if(preset != null)
                             {

--- a/DynamicBridge/Gui/GuiPresets.cs
+++ b/DynamicBridge/Gui/GuiPresets.cs
@@ -381,7 +381,7 @@ namespace DynamicBridge.Gui
                         if(C.EnableGlamourer)
                         {
                             ImGui.TableNextColumn();
-                            if (C.StickyGlamourer)
+                            if (C.StickyGlamourer && C.Sticky)
                             {
                                 SetWidthNextImGuiWithButtonToRight(FontAwesomeIcon.Dice);
                             }
@@ -498,7 +498,7 @@ namespace DynamicBridge.Gui
                             if(fullList != null) ImGuiEx.Tooltip(UI.RandomNotice + fullList);
 
                             //Add random Glamourer Button
-                            if (C.StickyGlamourer)
+                            if (C.StickyGlamourer && C.Sticky)
                             {
                                 ImGui.SameLine();
                                 if(ImGuiEx.IconButton(FontAwesomeIcon.Dice, "GlamourerButton"))
@@ -531,7 +531,7 @@ namespace DynamicBridge.Gui
                                 ImGuiEx.HelpMarker("All registered profiles are displayed in global profile, but only ones that are assigned to your current character will be used.", EColor.OrangeBright, FontAwesomeIcon.ExclamationTriangle.ToIconString(), false);
                                 ImGui.SameLine();
                             }
-                            if (C.StickyCustomize)
+                            if (C.StickyCustomize && C.Sticky)
                             {
                                 SetWidthNextImGuiWithButtonToRight(FontAwesomeIcon.Dice);
                             }
@@ -591,7 +591,7 @@ namespace DynamicBridge.Gui
                             }
                             if(fullList != null) ImGuiEx.Tooltip(UI.RandomNotice + fullList);
                             //Add random Customize+ Button
-                            if (C.StickyCustomize)
+                            if (C.StickyCustomize && C.Sticky)
                             {
                                 ImGui.SameLine();
                                 if(ImGuiEx.IconButton(FontAwesomeIcon.Dice,"CustomizeButton"))
@@ -624,7 +624,7 @@ namespace DynamicBridge.Gui
                                 ImGuiEx.HelpMarker("All registered titles are displayed in global profile, but only ones that are assigned to your current character will be used UNLESS \"Allow selecting titles registered for other characters\" is enabled in settings.", EColor.OrangeBright, FontAwesomeIcon.ExclamationTriangle.ToIconString(), false);
                                 ImGui.SameLine();
                             }
-                            if (C.StickyHonorific)
+                            if (C.StickyHonorific && C.Sticky)
                             {
                                 SetWidthNextImGuiWithButtonToRight(FontAwesomeIcon.Dice);
                             }
@@ -688,7 +688,7 @@ namespace DynamicBridge.Gui
                             }
                             if(fullList != null) ImGuiEx.Tooltip(UI.RandomNotice + fullList);
                             //Add random Honorific Button
-                            if (C.StickyHonorific)
+                            if (C.StickyHonorific && C.Sticky)
                             {
                                 ImGui.SameLine();
                                 if(ImGuiEx.IconButton(FontAwesomeIcon.Dice, "HonorificButton"))
@@ -716,7 +716,7 @@ namespace DynamicBridge.Gui
                         {
                             bool noresults = true;
                             ImGui.TableNextColumn();
-                            if (C.StickyPenumbra)
+                            if (C.StickyPenumbra && C.Sticky)
                             {
                                 SetWidthNextImGuiWithButtonToRight(FontAwesomeIcon.Dice);
                             }
@@ -777,7 +777,7 @@ namespace DynamicBridge.Gui
                                 ImGui.EndCombo();
                             }
                             if(fullList != null) ImGuiEx.Tooltip(UI.RandomNotice + fullList);
-                            if (C.StickyPenumbra)
+                            if (C.StickyPenumbra && C.Sticky)
                             {
                                 ImGui.SameLine();
                                 if(ImGuiEx.IconButton(FontAwesomeIcon.Dice, "PenumbraButton"))

--- a/DynamicBridge/Gui/GuiPresets.cs
+++ b/DynamicBridge/Gui/GuiPresets.cs
@@ -1,4 +1,4 @@
-﻿using Dalamud.Game.Text.SeStringHandling;
+using Dalamud.Game.Text.SeStringHandling;
 using DynamicBridge.Configuration;
 using DynamicBridge.IPC.Honorific;
 using ECommons.Configuration;
@@ -503,7 +503,6 @@ namespace DynamicBridge.Gui
                                 ImGui.SameLine();
                                 if(ImGuiEx.IconButton(FontAwesomeIcon.Dice, "GlamourerButton"))
                                 {
-                                    PluginLog.Debug("Attempting to randomize!");
                                     if (preset.Glamourer.Count + preset.ComplexGlamourer.Count > 1) {
                                         var old = preset.StickyRandomG;
                                         preset.StickyRandomG = Random.Shared.Next(0, preset.Glamourer.Count + preset.ComplexGlamourer.Count);
@@ -597,7 +596,6 @@ namespace DynamicBridge.Gui
                                 ImGui.SameLine();
                                 if(ImGuiEx.IconButton(FontAwesomeIcon.Dice,"CustomizeButton"))
                                 {
-                                    PluginLog.Debug("Attempting to randomize!");
                                     if (preset.CustomizeFiltered().ToArray().Length > 1) {
                                         var old = preset.StickyRandomC;
                                         preset.StickyRandomC = Random.Shared.Next(0, preset.CustomizeFiltered().ToArray().Length);
@@ -695,7 +693,6 @@ namespace DynamicBridge.Gui
                                 ImGui.SameLine();
                                 if(ImGuiEx.IconButton(FontAwesomeIcon.Dice, "HonorificButton"))
                                 {
-                                    PluginLog.Debug("Attempting to randomize!");
                                     if (preset.HonorificFiltered().ToArray().Length > 1) {
                                         var old = preset.StickyRandomH;
                                         preset.StickyRandomH = Random.Shared.Next(0, preset.HonorificFiltered().ToArray().Length);
@@ -785,7 +782,6 @@ namespace DynamicBridge.Gui
                                 ImGui.SameLine();
                                 if(ImGuiEx.IconButton(FontAwesomeIcon.Dice, "PenumbraButton"))
                                 {
-                                    PluginLog.Debug("Attempting to randomize!");
                                     if (preset.Penumbra.Count > 1) {
                                         var old = preset.StickyRandomP;
                                         preset.StickyRandomP = Random.Shared.Next(0, preset.Penumbra.Count);

--- a/DynamicBridge/Gui/GuiRules.cs
+++ b/DynamicBridge/Gui/GuiRules.cs
@@ -556,7 +556,7 @@ namespace DynamicBridge.Gui
                         {
                             Safe(() => Clipboard.SetText(JsonConvert.SerializeObject(rule)));
                         }
-                        if (C.StickyPresets){
+                        if (C.StickyPresets && C.Sticky){
                             ImGui.SameLine();
                             if(ImGuiEx.IconButton(FontAwesomeIcon.Dice))
                             {

--- a/DynamicBridge/Gui/GuiRules.cs
+++ b/DynamicBridge/Gui/GuiRules.cs
@@ -529,13 +529,19 @@ namespace DynamicBridge.Gui
                                     if(Filters[filterCnt].Length > 0 && !name.Contains(Filters[filterCnt], StringComparison.OrdinalIgnoreCase)) continue;
                                     if(OnlySelected[filterCnt] && !rule.SelectedPresets.Contains(name)) continue;
                                     if(x.GetFolder(Profile)?.HiddenFromSelection == true) continue;
-                                    ImGuiEx.CollectionCheckbox($"{x.CensoredName}##{x.GUID}", x.Name, rule.SelectedPresets);
+                                    if (ImGuiEx.CollectionCheckbox($"{x.CensoredName}##{x.GUID}", x.Name, rule.SelectedPresets))
+                                    {
+                                        rule.StickyRandom = Random.Shared.Next(0, rule.SelectedPresets.Count);
+                                    }
                                 }
                                 foreach(var x in rule.SelectedPresets)
                                 {
                                     if(designs.Any(d => d.Name == x && d.GetFolder(Profile)?.HiddenFromSelection != true)) continue;
                                     ImGui.PushStyleColor(ImGuiCol.Text, ImGuiColors.DalamudRed);
-                                    ImGuiEx.CollectionCheckbox($"{x}", x, rule.SelectedPresets, false, true);
+                                    if (ImGuiEx.CollectionCheckbox($"{x}", x, rule.SelectedPresets, false, true))
+                                    {
+                                        rule.StickyRandom = Random.Shared.Next(0, rule.SelectedPresets.Count);
+                                    }
                                     ImGui.PopStyleColor();
                                 }
                                 ImGui.EndCombo();
@@ -549,6 +555,23 @@ namespace DynamicBridge.Gui
                         if(ImGuiEx.IconButton(FontAwesomeIcon.Copy))
                         {
                             Safe(() => Clipboard.SetText(JsonConvert.SerializeObject(rule)));
+                        }
+                        if (C.StickyPresets){
+                            ImGui.SameLine();
+                            if(ImGuiEx.IconButton(FontAwesomeIcon.Dice))
+                            {
+                                if (rule.SelectedPresets.Count > 1) {
+                                    var old = rule.StickyRandom;
+                                    rule.StickyRandom = Random.Shared.Next(0, rule.SelectedPresets.Count);
+                                    P.ForceUpdate = true;
+                                    if (rule.StickyRandom == old) {
+                                        rule.StickyRandom = (rule.StickyRandom + 1)%rule.SelectedPresets.Count;
+                                    };
+
+                                }
+                                else {rule.StickyRandom = 0;}
+                            }
+                            ImGuiEx.Tooltip($"Randomize Preset Used.");
                         }
                         ImGui.SameLine();
                         if(ImGuiEx.IconButton(FontAwesomeIcon.Trash) && ImGui.GetIO().KeyCtrl)

--- a/DynamicBridge/Gui/GuiRules.cs
+++ b/DynamicBridge/Gui/GuiRules.cs
@@ -1,4 +1,4 @@
-﻿using Dalamud.Interface.Components;
+using Dalamud.Interface.Components;
 using Dalamud.Interface.Style;
 using DynamicBridge.Configuration;
 using DynamicBridge.Core;
@@ -567,7 +567,6 @@ namespace DynamicBridge.Gui
                                     if (rule.StickyRandom == old) {
                                         rule.StickyRandom = (rule.StickyRandom + 1)%rule.SelectedPresets.Count;
                                     };
-
                                 }
                                 else {rule.StickyRandom = 0;}
                             }

--- a/DynamicBridge/Gui/GuiSettings.cs
+++ b/DynamicBridge/Gui/GuiSettings.cs
@@ -55,6 +55,19 @@ public static class GuiSettings
             if (C.Sticky)
             {
                 ImGuiEx.Spacing();
+                ImGuiEx.SetNextItemWidthScaled(200f);
+                ImGuiEx.EnumCombo($"Randomize on Login", ref C.RandomChoosenType);
+                if (C.RandomChoosenType == RandomTypes.Timer) {
+                    ImGui.SameLine();
+                    ImGui.Text("| How often should it randomize everything in minutes:");
+                    ImGui.SameLine();
+                    ImGuiEx.SetNextItemWidthScaled(200f);
+                    if (ImGui.InputDouble("", ref C.UserInputRandomizerTime))
+                    {
+                        C.UserInputRandomizerTime = Math.Max(0.15, C.UserInputRandomizerTime);
+                    };
+                }
+                ImGuiEx.Spacing();
                 ImGui.Checkbox($"Attempt to preserve presets", ref C.StickyPresets);
                 ImGuiEx.Spacing();
                 ImGui.Checkbox($"Attempt to preserve glamourer", ref C.StickyGlamourer);

--- a/DynamicBridge/Gui/GuiSettings.cs
+++ b/DynamicBridge/Gui/GuiSettings.cs
@@ -66,7 +66,12 @@ public static class GuiSettings
                     ImGuiEx.SetNextItemWidthScaled(200f);
                     if (ImGui.InputDouble("", ref C.UserInputRandomizerTime))
                     {
-                        C.UserInputRandomizerTime = Math.Max(0.15, C.UserInputRandomizerTime);
+                        double ReloadSpeed = 1;
+                        if (!C.ForceUpdateOnRandomize) 
+                        {
+                            ReloadSpeed = 0.1;
+                        }
+                        C.UserInputRandomizerTime = Math.Max(ReloadSpeed, C.UserInputRandomizerTime);
                     };
                     ImGuiEx.Spacing();ImGuiEx.Spacing();
                     ImGui.Checkbox("Force update on randomize", ref C.ForceUpdateOnRandomize);

--- a/DynamicBridge/Gui/GuiSettings.cs
+++ b/DynamicBridge/Gui/GuiSettings.cs
@@ -49,7 +49,6 @@ public static class GuiSettings
                     P.Memory.EquipGearsetHook.Disable();
                 }
             }
-            ImGui.Checkbox($"Don't force update on territory change if applied rules don't change", ref C.DontChangeOnTerritoryChange); // Concise and clear wording?
             ImGuiEx.HelpMarker("Please ensure \"Revert Manual Changes on Zone Change\" is unchecked in Glamourer Behavior Settings");
             ImGui.Checkbox($"Attempt to preserve rules", ref C.Sticky);
             if (C.Sticky)

--- a/DynamicBridge/Gui/GuiSettings.cs
+++ b/DynamicBridge/Gui/GuiSettings.cs
@@ -1,4 +1,4 @@
-﻿using DynamicBridge.Configuration;
+using DynamicBridge.Configuration;
 using DynamicBridge.IPC.Glamourer;
 using Lumina.Excel.Sheets;
 using System;
@@ -59,13 +59,17 @@ public static class GuiSettings
                 ImGuiEx.EnumCombo($"Randomize on Login", ref C.RandomChoosenType);
                 if (C.RandomChoosenType == RandomTypes.Timer) {
                     ImGui.SameLine();
-                    ImGui.Text("| How often should it randomize everything in minutes:");
+                    ImGui.Text("|");
+                    ImGui.SameLine();
+                    ImGui.Text("How often should it randomize everything in minutes:");
                     ImGui.SameLine();
                     ImGuiEx.SetNextItemWidthScaled(200f);
                     if (ImGui.InputDouble("", ref C.UserInputRandomizerTime))
                     {
                         C.UserInputRandomizerTime = Math.Max(0.15, C.UserInputRandomizerTime);
                     };
+                    ImGuiEx.Spacing();ImGuiEx.Spacing();
+                    ImGui.Checkbox("Force update on randomize", ref C.ForceUpdateOnRandomize);
                 }
                 ImGuiEx.Spacing();
                 ImGui.Checkbox($"Attempt to preserve presets", ref C.StickyPresets);
@@ -74,7 +78,7 @@ public static class GuiSettings
                 ImGuiEx.Spacing();
                 ImGui.Checkbox($"Attempt to preserve customize", ref C.StickyCustomize);
                 ImGuiEx.Spacing();
-                ImGui.Checkbox($"Attempt to preserve honorific", ref C.StickyHonorific);
+                ImGui.Checkbox($"Attempt to preserve honorific   ", ref C.StickyHonorific); //Cheaty spaces to make it all line up
                 ImGuiEx.Spacing();
                 ImGui.Checkbox($"Attempt to preserve penumbra", ref C.StickyPenumbra);
             }

--- a/DynamicBridge/Gui/GuiSettings.cs
+++ b/DynamicBridge/Gui/GuiSettings.cs
@@ -49,6 +49,22 @@ public static class GuiSettings
                     P.Memory.EquipGearsetHook.Disable();
                 }
             }
+            ImGui.Checkbox($"Don't force update on territory change if applied rules don't change", ref C.DontChangeOnTerritoryChange); // Concise and clear wording?
+            ImGuiEx.HelpMarker("Please ensure \"Revert Manual Changes on Zone Change\" is unchecked in Glamourer Behavior Settings");
+            ImGui.Checkbox($"Attempt to preserve rules", ref C.Sticky);
+            if (C.Sticky)
+            {
+                ImGuiEx.Spacing();
+                ImGui.Checkbox($"Attempt to preserve presets", ref C.StickyPresets);
+                ImGuiEx.Spacing();
+                ImGui.Checkbox($"Attempt to preserve glamourer", ref C.StickyGlamourer);
+                ImGuiEx.Spacing();
+                ImGui.Checkbox($"Attempt to preserve customize", ref C.StickyCustomize);
+                ImGuiEx.Spacing();
+                ImGui.Checkbox($"Attempt to preserve honorific", ref C.StickyHonorific);
+                ImGuiEx.Spacing();
+                ImGui.Checkbox($"Attempt to preserve penumbra", ref C.StickyPenumbra);
+            }
             /*ImGui.Checkbox($"Force update appearance on manual gear changes", ref C.UpdateGearChange);
             ImGuiEx.HelpMarker("This option impacts performance", EColor.OrangeBright, FontAwesomeIcon.ExclamationTriangle.ToIconString());*/
             ImGui.Separator();


### PR DESCRIPTION
Make things sticky.
Rules attempt to apply a consistent preset.
Presets attempt to apply a consistent Glamourer/C+/Penumbra etc..

Adds randomize buttons so that if a user is unhappy with the current look, they may "randomize" which preset is used, or which glam is used in the preset. 

Example for how sticky presets works:
Rule 1 rolls random on P1, and has P2, P3, P4. Every time rule 1 is active from now on, it will use P1 instead of randomly selecting.

Example for how sticky Glamourer works:
Preset 1 has G1, G2, G3. It rolls G2 as the sticky glam. Every time Preset 1 is selected (by any rule) it will attempt to apply G2.

How does it roll?
Users have the option to enable each of the different sticky settings individually. If they only want Sticky Presets, and sticky Penumbra, they may opt to only check those 2 settings. Glamourer and C+ will then be rolled randomly each time an update occurs. 

Rolling options:
Users have the ability to change how often the stickyness is randomized. I have it set by default (I think) to re-rolling everything on login. However users may opt instead for never re-rolling (besides manually and individually for each), or re-rolling everything on a timer (and additional settings to force update every time that happens).

I will admit the "re-roll on login" is untested, but should hopefully work.

Additional rolling option that is unimplemented, but may be ideal is "time since last rule update."