### PR TITLE
Rezoning setting

### DIFF
--- a/DynamicBridge/Configuration/Config.cs
+++ b/DynamicBridge/Configuration/Config.cs
@@ -33,6 +33,7 @@ namespace DynamicBridge.Configuration
         public string LastVersion = "0";
         public ImGuiComboFlags ComboSize = ImGuiComboFlags.HeightLarge;
         public bool UpdateJobGSChange = true;
+        public bool DontChangeOnTerritoryChange = false;
         public bool UpdateGearChange = false;
         public Dictionary<ulong, string> SeenCharacters = [];
 

--- a/DynamicBridge/DynamicBridge.cs
+++ b/DynamicBridge/DynamicBridge.cs
@@ -306,7 +306,8 @@ public unsafe class DynamicBridge : IDalamudPlugin
                         }
                     }
                 }
-                if(ForceUpdate || !Utils.GuidEquals(newRule, LastRule) || (SoftForceUpdate && newRule.Count > 0))
+                bool DontChangeOnTerritoryChange = C.DontChangeOnTerritoryChange; // true: Don't change if rules are same on territory change, false (defualt): Use old method 
+                if(ForceUpdate || !Utils.GuidEquals(newRule, LastRule) || (SoftForceUpdate && newRule.Count > 0 && !DontChangeOnTerritoryChange))
                 {
                     PluginLog.Debug($"Old rule: {LastRule.Print()}, new rule: {newRule.Print()} | {Utils.GuidEquals(newRule, LastRule)} | F:{ForceUpdate}");
                     LastRule = newRule;

--- a/DynamicBridge/Gui/GuiSettings.cs
+++ b/DynamicBridge/Gui/GuiSettings.cs
@@ -49,6 +49,7 @@ public static class GuiSettings
                     P.Memory.EquipGearsetHook.Disable();
                 }
             }
+            ImGui.Checkbox($"Don't force update on territory change if applied rules don't change", ref C.DontChangeOnTerritoryChange); // Concise and clear wording?
             /*ImGui.Checkbox($"Force update appearance on manual gear changes", ref C.UpdateGearChange);
             ImGuiEx.HelpMarker("This option impacts performance", EColor.OrangeBright, FontAwesomeIcon.ExclamationTriangle.ToIconString());*/
             ImGui.Separator();

--- a/DynamicBridge/Gui/GuiSettings.cs
+++ b/DynamicBridge/Gui/GuiSettings.cs
@@ -50,6 +50,7 @@ public static class GuiSettings
                 }
             }
             ImGui.Checkbox($"Don't force update on territory change if applied rules don't change", ref C.DontChangeOnTerritoryChange); // Concise and clear wording?
+            ImGuiEx.HelpMarker("Please ensure \"Revert Manual Changes on Zone Change\" is unchecked in Glamourer Behavior Settings");
             /*ImGui.Checkbox($"Force update appearance on manual gear changes", ref C.UpdateGearChange);
             ImGuiEx.HelpMarker("This option impacts performance", EColor.OrangeBright, FontAwesomeIcon.ExclamationTriangle.ToIconString());*/
             ImGui.Separator();


### PR DESCRIPTION
Simple setting to not re-update character appearance when zone changes but every rule is still the same. 
Requires specific setting in Glamourer to be disabled. On hover, there is a tool tip stating this. 