### PR TITLE
Player rule selection

### DIFF
--- a/DynamicBridge/Configuration/ApplyRule.cs
+++ b/DynamicBridge/Configuration/ApplyRule.cs
@@ -25,6 +25,7 @@ namespace DynamicBridge.Configuration
         public List<ETime> Times = [];
         public List<uint> Worlds = [];
         public List<int> Gearsets = [];
+        public List<string> Players = [];
 
         public List<string> SelectedPresets = [];
         public bool Passthrough = false;
@@ -44,6 +45,7 @@ namespace DynamicBridge.Configuration
             public List<ETime> Times = [];
             public List<uint> Worlds = [];
             public List<int> Gearsets = [];
+            public List<string> Players = [];
         }
     }
 }

--- a/DynamicBridge/Configuration/Config.cs
+++ b/DynamicBridge/Configuration/Config.cs
@@ -47,6 +47,7 @@ namespace DynamicBridge.Configuration
         public bool Cond_Job = true;
         public bool Cond_World = false;
         public bool Cond_Gearset = false;
+        public bool Cond_Players = false;
 
         public Dictionary<ulong, List<GearsetEntry>> GearsetNameCacheCID = [];
 
@@ -57,6 +58,7 @@ namespace DynamicBridge.Configuration
         public bool UnifyJobs = true;
         public bool HonotificUnfiltered = false;
         public bool AutofillFromGlam = false;
+        public List<(string Name, float Distance)> selectedPlayers = new List<(string Name, float Distance)>();
     }
 
     public enum GlamourerNoRuleBehavior

--- a/DynamicBridge/DynamicBridge.cs
+++ b/DynamicBridge/DynamicBridge.cs
@@ -298,6 +298,9 @@ public unsafe class DynamicBridge : IDalamudPlugin
                                 &&
                                 (!C.Cond_Gearset || ((x.Gearsets.Count == 0 || x.Gearsets.Contains(RaptureGearsetModule.Instance()->CurrentGearsetIndex))
                                 && (!C.AllowNegativeConditions || !x.Not.Gearsets.Contains(RaptureGearsetModule.Instance()->CurrentGearsetIndex))))
+                                &&
+                                (!C.Cond_Players || (x.Players.Count == 0 || x.Players.Any(rp => GuiPlayers.SimpleNearbyPlayers().Any(sp => rp == sp.Name && C.selectedPlayers.Any(sel => sel.Name == sp.Name && (sel.Distance >= sp.Distance || sel.Distance >= 150f))))) 
+                                && (!C.AllowNegativeConditions || !x.Not.Players.Any(rp => GuiPlayers.SimpleNearbyPlayers().Any(sp => rp == sp.Name && C.selectedPlayers.Any(sel => sel.Name == sp.Name && (sel.Distance >= sp.Distance || sel.Distance >= 150f))))))
                                 )
                             {
                                 newRule.Add(x);

--- a/DynamicBridge/Gui/GuiPlayers.cs
+++ b/DynamicBridge/Gui/GuiPlayers.cs
@@ -7,7 +7,7 @@ using System.Text.RegularExpressions;
 namespace DynamicBridge.Gui;
 public class GuiPlayers
 {
-    internal static unsafe IEnumerable<IPlayerCharacter> GetNearbyPlayers()
+    internal static IEnumerable<IPlayerCharacter> GetNearbyPlayers()
     {
         if (Svc.Objects == null)
         {

--- a/DynamicBridge/Gui/GuiPlayers.cs
+++ b/DynamicBridge/Gui/GuiPlayers.cs
@@ -1,0 +1,238 @@
+using ECommons.GameHelpers;
+using Dalamud.Game.ClientState.Objects.SubKinds;
+using Dalamud.Game.ClientState.Objects.Enums; //For IPlayerCharacter
+using System.Text.RegularExpressions;
+
+
+namespace DynamicBridge.Gui;
+public class GuiPlayers
+{
+    internal static unsafe IEnumerable<IPlayerCharacter> GetNearbyPlayers()
+    {
+        if (Svc.Objects == null)
+        {
+            PluginLog.LogError("ObjectTable is null!");
+            return Enumerable.Empty<IPlayerCharacter>(); // Return an empty collection to prevent crashes
+        }
+
+        return Svc.Objects
+            .Where(x => x != null && x.IsValid()) // Ensure x is not null before calling IsValid()
+            .OfType<IPlayerCharacter>()
+            .Where(x => x.ObjectIndex < 240);
+    }
+
+    private static int GetFlagPriority(StatusFlags flag)
+    {
+        if (flag.HasFlag(StatusFlags.Friend)) return 1;
+        if (flag.HasFlag(StatusFlags.PartyMember)) return 2;
+        if (flag.HasFlag(StatusFlags.AllianceMember)) return 3;
+        return 999;
+    }
+
+    public static List<(string Name, int Priority, float Distance)> SimpleNearbyPlayers()
+    {    
+        List<(string Name, int Priority, float Distance)> result = new List<(string Name, int Priority, float Distance)>();
+
+        var players = GetNearbyPlayers()
+            .OrderBy(x => x.Name.TextValue, StringComparer.OrdinalIgnoreCase);
+
+        var you = players.FirstOrDefault(x => x.GameObjectId == Svc.ClientState.LocalPlayer?.GameObjectId);
+
+        foreach (var player in players)
+        {
+            if (player.GameObjectId == Svc.ClientState.LocalPlayer?.GameObjectId) continue;
+            int priority = GetFlagPriority(player.StatusFlags);
+            var distance = Vector3.Distance(you.Position, player.Position);
+            result.Add((player.GetNameWithWorld(), priority, distance)); // Tuple with Name & Priority
+        }
+
+        return result;
+    }
+
+    private static string newPlayerName = "";
+    private static string errorMessage = "";
+    private static int orderPrio = 1;
+    private static void ValidatePlayerName()
+    {
+        // Regular Expression for Validation
+        string pattern = @"^[A-Za-z'-]+ [A-Za-z'-]+@[A-Za-z'-]+$";
+        if (Regex.IsMatch(newPlayerName, pattern) || string.IsNullOrWhiteSpace(newPlayerName))
+        {
+            errorMessage = ""; // Valid input, clear error message
+            if (C.selectedPlayers.Any(p => p.Name == newPlayerName)) 
+            {
+                errorMessage = "Name already in Saved Names";
+            }
+        }
+        else
+        {
+            errorMessage = "Invalid format. Use: FirstName LastName@HomeWorld";
+        }
+    }
+
+    public static void Draw()
+    {
+        ImGui.Text("Add Player:");
+        ImGui.SameLine();
+        ImGui.SetNextItemWidth(ImGui.GetContentRegionAvail().X - 120f); // Input field takes most of the width
+        if (ImGui.InputTextWithHint("##newPlayer", "FirstName LastName@HomeWorld", ref newPlayerName, 80, ImGuiInputTextFlags.EnterReturnsTrue))
+        {
+            // If valid and Enter is pressed, add to the list
+            if (string.IsNullOrEmpty(errorMessage) && !string.IsNullOrWhiteSpace(newPlayerName) && !C.selectedPlayers.Any(p => p.Name == newPlayerName))
+            {
+                C.selectedPlayers.Add((newPlayerName, 150f));
+                newPlayerName = ""; // Clear input after adding
+            }
+        }
+        ValidatePlayerName();
+        // Show error message if validation fails
+        if (!string.IsNullOrEmpty(errorMessage))
+        {
+            ImGui.TextColored(new Vector4(1f, 0f, 0f, 1f), errorMessage); // Red text
+        }
+        else
+        {
+            ImGui.SameLine();
+            if (ImGui.Button("Add##CustomPlayer"))
+            {
+                PluginLog.Information($"Adding {newPlayerName} to list");
+                if (!string.IsNullOrWhiteSpace(newPlayerName) && !C.selectedPlayers.Any(p => p.Name == newPlayerName))
+                {
+                    C.selectedPlayers.Add((newPlayerName, 150f));
+                    newPlayerName = ""; // Clear input after adding
+                }
+            }
+            ImGui.Spacing();
+        }
+
+        float totalWidth = ImGui.GetContentRegionAvail().X;
+        float secondColumnWidth = totalWidth * 0.2f;
+
+        ImGui.Columns(2, "SplitColumns", true);
+        ImGui.SetColumnWidth(0, totalWidth - secondColumnWidth);
+        List<(string Name, int Priority, float Distance)> nearbyPlayers = SimpleNearbyPlayers();
+
+        List<(string Name, float Distance)> updatedPlayers = new List<(string, float)>();
+        List<string> removedPlayers = new List<string>();
+
+        if (ImGui.BeginTable("PlayerTable", 4, 
+            ImGuiTableFlags.RowBg | ImGuiTableFlags.Borders | ImGuiTableFlags.SizingStretchSame))
+        {
+            // Column Setup
+            ImGui.TableSetupColumn("", ImGuiTableColumnFlags.WidthFixed, 80f); // Remove Button (Fixed Width)
+            ImGui.TableSetupColumn("Player"); // Auto-size based on longest name
+            ImGui.TableSetupColumn("Max Distance to Apply Rules", ImGuiTableColumnFlags.WidthStretch); // Stretches to fill remaining space
+            ImGui.TableSetupColumn("Current Distance"); // Auto-size based on content
+            ImGui.TableHeadersRow();
+
+            if (C.selectedPlayers.Count > 0)
+            {
+                foreach (var playerData in C.selectedPlayers)
+                {
+                    string playerFullName = playerData.Name;
+                    float ruleDistance = playerData.Distance;
+
+                    // Find current distance from nearbyPlayers
+                    var nearbyPlayer = nearbyPlayers.FirstOrDefault(p => p.Name == playerFullName);
+                    float currentDistance = nearbyPlayer != default ? nearbyPlayer.Distance : -1f;
+                    bool isNearby = currentDistance >= 0;
+
+                    // Row Coloring (Green if currentDistance < ruleDistance)
+                    if (isNearby && currentDistance < ruleDistance)
+                    {
+                        ImGui.TableNextRow(ImGuiTableRowFlags.None, 0);
+                        ImGui.TableSetBgColor(ImGuiTableBgTarget.RowBg0, 
+                            ImGui.ColorConvertFloat4ToU32(new Vector4(0.2f, 0.6f, 0.2f, 0.5f))); // Light Green
+                    }
+                    else
+                    {
+                        ImGui.TableNextRow();
+                    }
+
+                    // Column 0: Remove Button (Fixed Size)
+                    ImGui.TableSetColumnIndex(0);
+                    if (ImGui.Button($"Remove##{playerFullName}"))
+                    {
+                        removedPlayers.Add(playerFullName);
+                    }
+
+                    // Column 1: Player Name (Auto-width)
+                    ImGui.TableSetColumnIndex(1);
+                    ImGui.Text(playerFullName);
+
+                    // Column 2: Rule Distance (Slider, Stretchable)
+                    ImGui.TableSetColumnIndex(2);
+                    ImGuiEx.SetNextItemFullWidth();
+                    if (ImGui.SliderFloat($"##distance_{playerFullName}", ref ruleDistance, 0f, 150f, "%.1f"))
+                    {
+                        updatedPlayers.Add((playerFullName, ruleDistance)); // Store the update separately
+                    }
+
+                    // Column 3: Current Distance (Auto-width)
+                    ImGui.TableSetColumnIndex(3);
+                    ImGui.Text(isNearby ? $"{currentDistance:F1}" : "Not Loaded");
+                }
+            }
+
+            ImGui.EndTable();
+
+            // Apply updates AFTER iteration to avoid modifying the list while looping
+            foreach (var updatedPlayer in updatedPlayers)
+            {
+                int index = C.selectedPlayers.FindIndex(p => p.Name == updatedPlayer.Name);
+                if (index != -1)
+                {
+                    C.selectedPlayers[index] = updatedPlayer;
+                }
+            }
+
+            var removedPlayerNames = new HashSet<string>(removedPlayers);
+            C.selectedPlayers = C.selectedPlayers.Where(p => !removedPlayerNames.Contains(p.Name)).ToList();
+        }
+
+
+        ImGui.NextColumn();
+
+        // Right Column - Nearby Players List
+        ImGui.Text("Nearby Players");
+
+        // Filter nearby players based on input
+        var filteredPlayers = string.IsNullOrEmpty(newPlayerName) 
+            ? nearbyPlayers 
+            : nearbyPlayers.Where(p => p.Name.Contains(newPlayerName, StringComparison.OrdinalIgnoreCase)).ToList();
+        
+        if (orderPrio == 0) {
+            if(ImGui.Button("Order by Name")) {
+                filteredPlayers.OrderBy(x => x.Name);
+                orderPrio = 1;
+            }
+        } 
+        if (orderPrio == 1) {
+            if(ImGui.Button("Order by Friends/Party")) {
+                filteredPlayers.OrderBy(x => x.Priority).ThenBy(x => x.Name);
+                orderPrio = 2;
+            }
+        }
+        if (orderPrio == 2) {
+            if(ImGui.Button("Order by Distance")) {
+                filteredPlayers.OrderBy(x => x.Distance);
+                orderPrio = 0;
+            }
+        }
+        foreach (var player in filteredPlayers)
+        {
+            if (!C.selectedPlayers.Any(p => p.Name == player.Name))
+            {
+                if (ImGui.Button($"Add##{player.Name}")) 
+                {
+                    C.selectedPlayers.Add((player.Name, 150f));
+                }
+                ImGui.SameLine();
+                ImGui.Text(player.Name);
+            }
+        }
+
+        ImGui.Columns(1);
+    }
+}
+

--- a/DynamicBridge/Gui/GuiRules.cs
+++ b/DynamicBridge/Gui/GuiRules.cs
@@ -23,7 +23,7 @@ namespace DynamicBridge.Gui
     {
         private static Vector2 iconSize => new(24f);
 
-        private static string[] Filters = ["", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", ""];
+        private static string[] Filters = ["", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", ""];
         private static bool[] OnlySelected = new bool[20];
         private static string CurrentDrag = "";
 
@@ -78,6 +78,7 @@ namespace DynamicBridge.Gui
                     C.Cond_World,
                     C.Cond_Zone,
                     C.Cond_ZoneGroup,
+                    C.Cond_Players,
                 ];
 
                 List<(Vector2 RowPos, Vector2 ButtonPos, Action BeginDraw, Action AcceptDraw)> MoveCommands = [];
@@ -97,6 +98,7 @@ namespace DynamicBridge.Gui
                     if(C.Cond_Job) ImGui.TableSetupColumn("Job");
                     if(C.Cond_World) ImGui.TableSetupColumn("World");
                     if(C.Cond_Gearset) ImGui.TableSetupColumn("Gearset");
+                    if(C.Cond_Players) ImGui.TableSetupColumn("Players");
                     ImGui.TableSetupColumn("Preset");
                     ImGui.TableSetupColumn(" ", ImGuiTableColumnFlags.NoResize | ImGuiTableColumnFlags.WidthFixed);
                     ImGui.TableHeadersRow();
@@ -511,6 +513,48 @@ namespace DynamicBridge.Gui
                             }
 
                             if(fullList != null) ImGuiEx.Tooltip(UI.AnyNotice + fullList);
+                        }
+                        filterCnt++;
+
+                        if (C.Cond_Players)
+                        {
+                            ImGui.TableNextColumn();
+                            
+                            // Player Selection Dropdown
+                            ImGui.SetNextItemWidth(ImGui.GetContentRegionAvail().X);
+                            if (ImGui.BeginCombo("##players", rule.Players.Select(x => C.selectedPlayers.FirstOrDefault(p => x == p.Name).Name ?? $"{x:X16}").PrintRange(rule.Not.Players.Select(x => C.selectedPlayers.FirstOrDefault(p => x == p.Name).Name ?? $"{x:X16}"), out var fullList), C.ComboSize))
+                            {
+                                FiltersSelection();
+
+                                foreach (var player in C.selectedPlayers)
+                                {
+                                    var name = player.Name;
+
+                                    // Apply filtering
+                                    if (Filters[filterCnt].Length > 0 && !name.Contains(Filters[filterCnt], StringComparison.OrdinalIgnoreCase))
+                                        continue;
+                                    if (OnlySelected[filterCnt] && !rule.Players.Contains(name))
+                                        continue;
+
+                                    DrawSelector($"{name}##{player.Name}", player.Name, rule.Players, rule.Not.Players);
+                                }
+
+                                // Handle players that no longer exist in `C.selectedPlayers` but are still in `rule.Players`
+                                foreach (var z in rule.Players)
+                                {
+                                    if (!C.selectedPlayers.Any(p => p.Name == z))
+                                    {
+                                        ImGui.PushStyleColor(ImGuiCol.Text, ImGuiColors.DalamudRed);
+                                        ImGuiEx.CollectionCheckbox($"{z}", z, rule.Players, delayedOperation: true);
+                                        ImGui.PopStyleColor();
+                                    }
+                                }
+
+                                ImGui.EndCombo();
+                            }
+
+                            if (fullList != null) 
+                                ImGuiEx.Tooltip(UI.AnyNotice + fullList);
                         }
                         filterCnt++;
 

--- a/DynamicBridge/Gui/GuiSettings.cs
+++ b/DynamicBridge/Gui/GuiSettings.cs
@@ -85,6 +85,7 @@ public static class GuiSettings
                 () => ImGui.Checkbox($"Job", ref C.Cond_Job),
                 () => ImGui.Checkbox($"World", ref C.Cond_World),
                 () => ImGui.Checkbox($"Gearset", ref C.Cond_Gearset),
+                () => ImGui.Checkbox($"Nearby Players", ref C.Cond_Players),
             ],
                 (int)(ImGui.GetContentRegionAvail().X / 180f), ImGuiTableFlags.BordersInner);
             ImGuiGroup.EndGroupBox();

--- a/DynamicBridge/Gui/UI.cs
+++ b/DynamicBridge/Gui/UI.cs
@@ -51,6 +51,7 @@ public static unsafe class UI
             ("House Registration", HouseReg.Draw, Colors.TabPurple, true),
             ("Profiles", GuiProfiles.Draw, Colors.TabBlue, true),
             ("Characters", GuiCharacters.Draw, Colors.TabBlue, true),
+            ("Other Players", GuiPlayers.Draw, Colors.TabBlue, true),
             ("Settings", GuiSettings.Draw, null, true),
             InternalLog.ImGuiTab(),
             (C.Debug?"Debug":null, Debug.Draw, ImGuiColors.DalamudGrey3, true),


### PR DESCRIPTION
Adds new menu option for for users to apply rules based on player distance. 

Add players to the new "Other players" menu either from nearby, or from a custom input. Then set how close you would like them to be before any rules are applied in the same menu!
*Must have "players" extra rule enabled. 

There is no censoring of names.
This feature is not implemented per-profile.
Rule player names are saved in the config file. Unsure if that's the best place.

I could potentially see the nearby players list being a non-optimal/slow implementation, or just problems with having a nearby players list. The list has simple sorting options for "friends/in party" as well as "distance" and "alphabetical." 