### PR TITLE
Implement Precise Time

### DIFF
--- a/DynamicBridge/Checkers/ETimeChecker.cs
+++ b/DynamicBridge/Checkers/ETimeChecker.cs
@@ -17,7 +17,7 @@ public static unsafe class ETimeChecker
         [ETime.Dawn] = "5am - 7am",
         [ETime.Dusk] = "5pm - 7pm",
         [ETime.Morning] = "7am - 12pm",
-        [ETime.Evening] = "7pm - 10am",
+        [ETime.Evening] = "7pm - 10pm",
     };
 
     public static ETime GetEorzeanTimeInterval() => GetTimeInterval(*ET);
@@ -32,5 +32,13 @@ public static unsafe class ETimeChecker
         if(date.Hour < 19) return ETime.Dusk;
         if(date.Hour < 22) return ETime.Evening;
         return ETime.Night;
+    }
+
+    public static float GetEorzeanTime() => GetTime(*ET);
+    public static float GetTime(long time)
+    {
+        var date = DateTimeOffset.FromUnixTimeSeconds(time);
+        // PluginLog.Information(((date.Hour*60+date.Minute)/(float)(24*60)).ToString());
+        return (date.Hour*60+date.Minute)/(float)(24*60);
     }
 }

--- a/DynamicBridge/Configuration/ApplyRule.cs
+++ b/DynamicBridge/Configuration/ApplyRule.cs
@@ -27,7 +27,15 @@ namespace DynamicBridge.Configuration
         public List<uint> Worlds = [];
         public List<int> Gearsets = [];
         public List<string> Players = [];
-
+        public List<TimelineSegment> Precise_Times = [
+            new TimelineSegment((float)0/24,(float)5/24,0),
+            new TimelineSegment((float)5/24,(float)7/24,0),
+            new TimelineSegment((float)7/24,(float)12/24,0),
+            new TimelineSegment((float)12/24,(float)17/24,0),
+            new TimelineSegment((float)17/24,(float)19/24,0),
+            new TimelineSegment((float)19/24,(float)22/24,0),
+            new TimelineSegment((float)22/24,(float)24/24,0)
+            ];
         public List<string> SelectedPresets = [];
         public bool Passthrough = false;
         public NotConditions Not = new();

--- a/DynamicBridge/Configuration/Config.cs
+++ b/DynamicBridge/Configuration/Config.cs
@@ -59,6 +59,7 @@ namespace DynamicBridge.Configuration
         public bool Cond_Gearset = false;
         public bool Cond_Players = false;
 
+        public bool Cond_Time_Precise = false;
         public Dictionary<ulong, List<GearsetEntry>> GearsetNameCacheCID = [];
 
         public string CensorSeed = Guid.NewGuid().ToString();

--- a/DynamicBridge/DynamicBridge.cs
+++ b/DynamicBridge/DynamicBridge.cs
@@ -342,8 +342,11 @@ public unsafe class DynamicBridge : IDalamudPlugin
                                 (!C.Cond_Job || ((x.Jobs.Count == 0 || x.Jobs.Contains(Player.Job.GetUpgradedJobIfNeeded()))
                                 && (!C.AllowNegativeConditions || !x.Not.Jobs.Contains(Player.Job.GetUpgradedJobIfNeeded()))))
                                 &&
-                                (!C.Cond_Time || ((x.Times.Count == 0 || x.Times.Contains(ETimeChecker.GetEorzeanTimeInterval()))
+                                (!C.Cond_Time && !C.Cond_Time_Precise || ((x.Times.Count == 0 || x.Times.Contains(ETimeChecker.GetEorzeanTimeInterval()))
                                 && (!C.AllowNegativeConditions || !x.Not.Times.Contains(ETimeChecker.GetEorzeanTimeInterval()))))
+                                &&
+                                (!C.Cond_Time_Precise || ((x.Precise_Times.Count == 0 || x.Precise_Times.All(segment => segment.State != 1) || x.Precise_Times.Any(segment => ETimeChecker.GetEorzeanTime() >= segment.Start && ETimeChecker.GetEorzeanTime() <= segment.End && segment.State == 1))
+                                && (!C.AllowNegativeConditions || !x.Precise_Times.Any(segment => ETimeChecker.GetEorzeanTime() >= segment.Start && ETimeChecker.GetEorzeanTime() <= segment.End && segment.State == 2))))
                                 &&
                                 (!C.Cond_World || ((x.Worlds.Count == 0 || x.Worlds.Contains(Player.Object.CurrentWorld.RowId))
                                 && (!C.AllowNegativeConditions || !x.Not.Worlds.Contains(Player.Object.CurrentWorld.RowId))))

--- a/DynamicBridge/Gui/GuiRules.cs
+++ b/DynamicBridge/Gui/GuiRules.cs
@@ -799,14 +799,10 @@ namespace DynamicBridge.Gui
                 }
             }
 
-            if (hoveringTimeline)
-            {
-                string timeLabel = FormatTime(hoverTime);
-                ImGui.SetTooltip(timeLabel);
-            }
-
             List<Vector2> labelBoundryBoxes = [];
             // Draw points + Identify if removeable
+            string hoverLabel = FormatTime(hoverTime);
+            string tooltipText = $"{hoverLabel} | Mouse Middle to add";
             for (int i = 0; i < timePoints.Count; i++)
             {
                 float xPos = startX + timePoints[i] * timelineWidth;
@@ -817,7 +813,13 @@ namespace DynamicBridge.Gui
                     color = ImGui.GetColorU32(new Vector4(1.0f, 0.5f, 0.0f, 1.0f));
                 }
                 string label = FormatTime(timePoints[i]);
-                
+
+                if (hoveringTimeline && Math.Abs(hoverTime - timePoints[i]) < 10f / timelineWidth)
+                {
+                    if (timePoints[i] == 0f || timePoints[i] == 1f) {tooltipText = $"{label} | May not remove";}
+                    else {tooltipText = $"{label} | Mouse Middle to remove.";}
+                }
+
                 Vector2 textSize = ImGui.CalcTextSize(label);
 
                 float labelX = xPos - textSize.X / 2;
@@ -839,6 +841,10 @@ namespace DynamicBridge.Gui
                 }
                 labelBoundryBoxes.Add(new Vector2(xPos+textSize.X/2, labelY));
                 drawList.AddCircleFilled(pointPos, 5f, color);
+            }
+            if (hoveringTimeline)
+            {
+                ImGui.SetTooltip(tooltipText);
             }
 
             timePoints = timePoints.Distinct().OrderBy(x => Vector2.Distance(mousePos, new Vector2(startX + x * timelineWidth, centerY))).ToList();

--- a/DynamicBridge/Gui/GuiSettings.cs
+++ b/DynamicBridge/Gui/GuiSettings.cs
@@ -1,4 +1,5 @@
 using DynamicBridge.Configuration;
+using DynamicBridge.Core;
 using DynamicBridge.IPC.Glamourer;
 using Lumina.Excel.Sheets;
 using System;
@@ -130,6 +131,24 @@ public static class GuiSettings
                 () => ImGui.Checkbox($"Nearby Players", ref C.Cond_Players),
             ],
                 (int)(ImGui.GetContentRegionAvail().X / 180f), ImGuiTableFlags.BordersInner);
+            if (C.Cond_Time)
+            {
+                ImGui.Separator();
+                ImGui.Checkbox("Enable Precise Time", ref C.Cond_Time_Precise);
+                if (C.Cond_Time_Precise)
+                {
+                    ImGui.SameLine();
+                    if(ImGui.Button("Convert all Simple Times to Precise Times") && ImGui.GetIO().KeyCtrl)
+                    {
+                        ConvertTimeRules();
+                    }
+                    ImGuiEx.Tooltip("Hold CTRL+Click, deletes all current Precise Times");
+                }
+            }
+            else 
+            {
+                C.Cond_Time_Precise = false;
+            }
             ImGuiGroup.EndGroupBox();
         }
 
@@ -198,6 +217,25 @@ public static class GuiSettings
         {
             GuiAbout.Draw();
             ImGuiGroup.EndGroupBox();
+        }
+    }
+
+    private static void ConvertTimeRules()
+    {
+        foreach (Profile profile in C.ProfilesL)
+        {
+            foreach (ApplyRule rule in profile.Rules)
+            {
+                rule.Precise_Times = [
+                    new TimelineSegment(0f / 24, 5f / 24, rule.Not.Times.Contains(ETime.Night) ? 2 : rule.Times.Contains(ETime.Night) ? 1 : 0),
+                    new TimelineSegment(5f / 24, 7f / 24, rule.Not.Times.Contains(ETime.Dawn) ? 2 : rule.Times.Contains(ETime.Dawn) ? 1 : 0),
+                    new TimelineSegment(7f / 24, 12f / 24, rule.Not.Times.Contains(ETime.Morning) ? 2 : rule.Times.Contains(ETime.Morning) ? 1 : 0),
+                    new TimelineSegment(12f / 24, 17f / 24, rule.Not.Times.Contains(ETime.Day) ? 2 : rule.Times.Contains(ETime.Day) ? 1 : 0),
+                    new TimelineSegment(17f / 24, 19f / 24, rule.Not.Times.Contains(ETime.Dusk) ? 2 : rule.Times.Contains(ETime.Dusk) ? 1 : 0),
+                    new TimelineSegment(19f / 24, 22f / 24, rule.Not.Times.Contains(ETime.Evening) ? 2 : rule.Times.Contains(ETime.Evening) ? 1 : 0),
+                    new TimelineSegment(22f / 24, 24f / 24, rule.Not.Times.Contains(ETime.Night) ? 2 : rule.Times.Contains(ETime.Night) ? 1 : 0)
+                ];
+            }
         }
     }
 

--- a/DynamicBridge/Structs/TimelineSegment.cs
+++ b/DynamicBridge/Structs/TimelineSegment.cs
@@ -1,0 +1,15 @@
+namespace DynamicBridge.Core;
+
+public struct TimelineSegment
+{
+    public float Start;  // Starting time (0-1)
+    public float End;    // Ending time (0-1)
+    public int State;  // Segment state
+    
+    public TimelineSegment(float start, float end, int state)
+    {
+        Start = start;
+        End = end;
+        State = state;
+    }
+}


### PR DESCRIPTION
Potentially resolves #46
Also fixes a small typo in the ETimeChecker Names. 10am -> 10pm. 

Only thing really is maybe a better UI for precise times. The open/close button is pretty ugly. The Timeline itself is very neat, but perhaps more granularity? Or maybe better controls. (The tool tip for add/remove is a lil big.)

Maybe small danger with giving users the ability to reset the Precise Times by converting from Simple Times, but couldn't think of a more elegant approach. All or nothing I guess. Button can't be clicked without holding Ctrl + Click + reading that notice. 